### PR TITLE
Add WPF SVG converter with batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 - 💞️ I’m looking to collaborate on ...
 - 📫 How to reach me ...
 
-<!---
-BuzzTKay/BuzzTKay is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## SVG Format Converter
+
+Dieses Repository enthält nun das WPF-Projekt **SvgConverterApp**. Die Anwendung ermöglicht das Konvertieren von SVG-Dateien zwischen den Formaten:
+
+- Standard SVG
+- Inkscape SVG
+- Siemens SVG HMI
+
+### Features
+
+- Dunkles, modernes UI mit klarer Struktur
+- Auswahl einzelner oder mehrerer SVG-Dateien
+- Automatischer Speicherdialog für Einzeldateien
+- Batch-Verarbeitung mit Zielordnerauswahl
+- Aktivitätenprotokoll und Statusmeldungen
+
+### Entwicklung
+
+Das Projekt ist für .NET 8.0 (Windows) konfiguriert. Öffne `SvgConverterApp/SvgConverterApp.csproj` in Visual Studio oder einer kompatiblen IDE, um die Anwendung zu starten.

--- a/SvgConverterApp/App.xaml
+++ b/SvgConverterApp/App.xaml
@@ -1,0 +1,63 @@
+<Application x:Class="SvgConverterApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <Color x:Key="PrimaryBackgroundColor">#FF1E1E1E</Color>
+            <Color x:Key="SecondaryBackgroundColor">#FF2C2C2C</Color>
+            <Color x:Key="AccentColor">#FF4FC3F7</Color>
+            <Color x:Key="TextColor">#FFF5F5F5</Color>
+
+            <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="{StaticResource PrimaryBackgroundColor}" />
+            <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="{StaticResource SecondaryBackgroundColor}" />
+            <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+            <SolidColorBrush x:Key="TextBrush" Color="{StaticResource TextColor}" />
+
+            <Style TargetType="Window">
+                <Setter Property="Background" Value="{StaticResource PrimaryBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+            </Style>
+
+            <Style TargetType="Button">
+                <Setter Property="Background" Value="{StaticResource AccentBrush}" />
+                <Setter Property="Foreground" Value="Black" />
+                <Setter Property="Padding" Value="10,6" />
+                <Setter Property="Margin" Value="0,8,0,0" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="{TemplateBinding Background}" CornerRadius="4">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+            </Style>
+
+            <Style TargetType="ComboBox">
+                <Setter Property="Background" Value="{StaticResource SecondaryBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                <Setter Property="Margin" Value="0,8,0,0" />
+            </Style>
+
+            <Style TargetType="ListBox">
+                <Setter Property="Background" Value="{StaticResource SecondaryBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                <Setter Property="Margin" Value="0,8,0,0" />
+            </Style>
+
+            <Style TargetType="TextBox">
+                <Setter Property="Background" Value="{StaticResource SecondaryBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/SvgConverterApp/App.xaml.cs
+++ b/SvgConverterApp/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace SvgConverterApp;
+
+public partial class App : Application
+{
+}

--- a/SvgConverterApp/Commands/AsyncRelayCommand.cs
+++ b/SvgConverterApp/Commands/AsyncRelayCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace SvgConverterApp.Commands;
+
+public class AsyncRelayCommand : ICommand
+{
+    private readonly Func<Task> _execute;
+    private readonly Func<bool>? _canExecute;
+    private bool _isExecuting;
+
+    public AsyncRelayCommand(Func<Task> execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public bool CanExecute(object? parameter) => !_isExecuting && (_canExecute?.Invoke() ?? true);
+
+    public async void Execute(object? parameter) => await ExecuteAsync();
+
+    public async Task ExecuteAsync()
+    {
+        if (_isExecuting)
+        {
+            return;
+        }
+
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute();
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/SvgConverterApp/Commands/RelayCommand.cs
+++ b/SvgConverterApp/Commands/RelayCommand.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Windows.Input;
+
+namespace SvgConverterApp.Commands;
+
+public class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    public event EventHandler? CanExecuteChanged;
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/SvgConverterApp/MainWindow.xaml
+++ b/SvgConverterApp/MainWindow.xaml
@@ -1,0 +1,77 @@
+<Window x:Class="SvgConverterApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SvgConverterApp"
+        mc:Ignorable="d"
+        Title="SVG Format Converter" Height="520" Width="780" MinHeight="480" MinWidth="720">
+    <Grid Margin="32">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Vertical">
+            <TextBlock Text="SVG Format Converter" FontSize="28" FontWeight="Bold" />
+            <TextBlock Text="Konvertiere Dateien zwischen Standard-, Inkscape- und Siemens SVG-HMI-Formaten." 
+                       Opacity="0.8" Margin="0,6,0,0" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,24,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="32" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel>
+                <TextBlock Text="Eingabeformat" FontWeight="SemiBold" />
+                <ComboBox ItemsSource="{Binding Formats}"
+                          SelectedItem="{Binding SelectedInputFormat}" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="2">
+                <TextBlock Text="Zielformat" FontWeight="SemiBold" />
+                <ComboBox ItemsSource="{Binding Formats}"
+                          SelectedItem="{Binding SelectedOutputFormat}" />
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="2" Margin="0,24,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="3*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <TextBlock Text="Ausgewählte Dateien" FontWeight="SemiBold" />
+                <ListBox ItemsSource="{Binding SelectedFiles}" Height="220" />
+                <Button Content="Dateien auswählen" Command="{Binding BrowseFilesCommand}" />
+                <TextBlock Text="Halte Strg gedrückt, um mehrere Dateien zu wählen." FontSize="12" Opacity="0.7" Margin="0,4,0,0" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="1" Margin="24,0,0,0">
+                <TextBlock Text="Aktivität" FontWeight="SemiBold" />
+                <Border Background="{StaticResource SecondaryBackgroundBrush}" CornerRadius="4" Padding="12" Margin="0,8,0,0" Height="220">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding ActivityLog}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}" TextWrapping="Wrap" Margin="0,0,0,6" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Border>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="3" Margin="0,24,0,0">
+            <Button Content="Konvertierung starten" Command="{Binding ConvertCommand}" />
+            <TextBlock Text="{Binding StatusMessage}" Margin="0,8,0,0" Opacity="0.8" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/SvgConverterApp/MainWindow.xaml.cs
+++ b/SvgConverterApp/MainWindow.xaml.cs
@@ -1,0 +1,16 @@
+using SvgConverterApp.Services;
+using SvgConverterApp.ViewModels;
+using System.Windows;
+
+namespace SvgConverterApp;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        var dialogService = new FileDialogService(this);
+        var conversionService = new SvgConversionService();
+        DataContext = new MainViewModel(dialogService, conversionService);
+    }
+}

--- a/SvgConverterApp/Models/SvgFormat.cs
+++ b/SvgConverterApp/Models/SvgFormat.cs
@@ -1,0 +1,8 @@
+namespace SvgConverterApp.Models;
+
+public enum SvgFormat
+{
+    Standard,
+    Inkscape,
+    SiemensSvghmi
+}

--- a/SvgConverterApp/Services/FileDialogService.cs
+++ b/SvgConverterApp/Services/FileDialogService.cs
@@ -1,0 +1,58 @@
+using Microsoft.Win32;
+using System.Collections.Generic;
+using System.Windows;
+using Forms = System.Windows.Forms;
+
+namespace SvgConverterApp.Services;
+
+public class FileDialogService : IFileDialogService
+{
+    private readonly Window _owner;
+
+    public FileDialogService(Window owner)
+    {
+        _owner = owner;
+    }
+
+    public IReadOnlyList<string>? OpenFiles(string filter, bool allowMultiple)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Filter = filter,
+            Multiselect = allowMultiple,
+            DefaultExt = ".svg"
+        };
+
+        return dialog.ShowDialog(_owner) == true ? dialog.FileNames : null;
+    }
+
+    public string? SaveFile(string defaultFileName, string filter)
+    {
+        var dialog = new SaveFileDialog
+        {
+            FileName = defaultFileName,
+            Filter = filter,
+            DefaultExt = ".svg"
+        };
+
+        return dialog.ShowDialog(_owner) == true ? dialog.FileName : null;
+    }
+
+    public string? SelectFolder()
+    {
+        using var dialog = new Forms.FolderBrowserDialog();
+        return dialog.ShowDialog(new WindowWrapper(new System.Windows.Interop.WindowInteropHelper(_owner).Handle)) == Forms.DialogResult.OK
+            ? dialog.SelectedPath
+            : null;
+    }
+
+    private sealed class WindowWrapper : Forms.IWin32Window
+    {
+        public WindowWrapper(nint handle)
+        {
+            Handle = handle;
+        }
+
+        public nint Handle { get; }
+    }
+}

--- a/SvgConverterApp/Services/IFileDialogService.cs
+++ b/SvgConverterApp/Services/IFileDialogService.cs
@@ -1,0 +1,8 @@
+namespace SvgConverterApp.Services;
+
+public interface IFileDialogService
+{
+    IReadOnlyList<string>? OpenFiles(string filter, bool allowMultiple);
+    string? SaveFile(string defaultFileName, string filter);
+    string? SelectFolder();
+}

--- a/SvgConverterApp/Services/ISvgConversionService.cs
+++ b/SvgConverterApp/Services/ISvgConversionService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SvgConverterApp.Models;
+
+namespace SvgConverterApp.Services;
+
+public interface ISvgConversionService
+{
+    Task<string> ConvertAsync(string svgContent, SvgFormat inputFormat, SvgFormat outputFormat, CancellationToken cancellationToken = default);
+}

--- a/SvgConverterApp/Services/SvgConversionService.cs
+++ b/SvgConverterApp/Services/SvgConversionService.cs
@@ -1,0 +1,174 @@
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Xml.Linq;
+using SvgConverterApp.Models;
+
+namespace SvgConverterApp.Services;
+
+public class SvgConversionService : ISvgConversionService
+{
+    private static readonly XNamespace SvgNamespace = "http://www.w3.org/2000/svg";
+    private static readonly XNamespace InkscapeNamespace = "http://www.inkscape.org/namespaces/inkscape";
+    private static readonly XNamespace SodipodiNamespace = "http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd";
+    private static readonly XNamespace SiemensNamespace = "http://www.siemens.com/schemas/svghmi/1.0";
+
+    public Task<string> ConvertAsync(string svgContent, SvgFormat inputFormat, SvgFormat outputFormat, CancellationToken cancellationToken = default)
+    {
+        if (outputFormat == inputFormat)
+        {
+            return Task.FromResult(svgContent);
+        }
+
+        return Task.Run(() => ConvertInternal(svgContent, inputFormat, outputFormat), cancellationToken);
+    }
+
+    private string ConvertInternal(string svgContent, SvgFormat inputFormat, SvgFormat outputFormat)
+    {
+        var document = XDocument.Parse(svgContent, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+        NormalizeDocument(document, inputFormat);
+        ApplyTargetFormat(document, outputFormat);
+
+        EnsureDeclaration(document);
+        return document.ToString(SaveOptions.DisableFormatting);
+    }
+
+    private static void NormalizeDocument(XDocument document, SvgFormat inputFormat)
+    {
+        if (document.Root is null)
+        {
+            throw new InvalidOperationException("Das Dokument enthält kein Root-Element.");
+        }
+
+        // Always ensure default SVG namespace
+        if (document.Root.Name.Namespace == XNamespace.None)
+        {
+            document.Root.Name = SvgNamespace + document.Root.Name.LocalName;
+        }
+
+        switch (inputFormat)
+        {
+            case SvgFormat.Inkscape:
+                StripNamespace(document.Root, InkscapeNamespace);
+                StripNamespace(document.Root, SodipodiNamespace);
+                RemoveMetadataByPrefix(document.Root, "inkscape");
+                RemoveMetadataByPrefix(document.Root, "sodipodi");
+                break;
+            case SvgFormat.SiemensSvghmi:
+                StripNamespace(document.Root, SiemensNamespace);
+                RemoveMetadataByPrefix(document.Root, "siemens");
+                break;
+        }
+    }
+
+    private static void ApplyTargetFormat(XDocument document, SvgFormat outputFormat)
+    {
+        if (document.Root is null)
+        {
+            throw new InvalidOperationException("Das Dokument enthält kein Root-Element.");
+        }
+
+        switch (outputFormat)
+        {
+            case SvgFormat.Standard:
+                ApplyStandardMetadata(document.Root);
+                break;
+            case SvgFormat.Inkscape:
+                ApplyInkscapeMetadata(document.Root);
+                break;
+            case SvgFormat.SiemensSvghmi:
+                ApplySiemensMetadata(document.Root);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(outputFormat), outputFormat, null);
+        }
+    }
+
+    private static void ApplyStandardMetadata(XElement root)
+    {
+        root.SetAttributeValue(XNamespace.Xmlns + "inkscape", null);
+        root.SetAttributeValue(XNamespace.Xmlns + "sodipodi", null);
+        root.SetAttributeValue(XNamespace.Xmlns + "siemens", null);
+        root.SetAttributeValue(XNamespace.Xmlns + "xlink", "http://www.w3.org/1999/xlink");
+        root.SetAttributeValue("version", root.Attribute("version")?.Value ?? "1.1");
+    }
+
+    private static void ApplyInkscapeMetadata(XElement root)
+    {
+        root.SetAttributeValue(XNamespace.Xmlns + "inkscape", InkscapeNamespace.NamespaceName);
+        root.SetAttributeValue(XNamespace.Xmlns + "sodipodi", SodipodiNamespace.NamespaceName);
+        root.SetAttributeValue("inkscape:version", "1.3");
+        root.SetAttributeValue("sodipodi:docname", CreateSafeFileName(root.Attribute("id")?.Value ?? "document"));
+    }
+
+    private static void ApplySiemensMetadata(XElement root)
+    {
+        root.SetAttributeValue(XNamespace.Xmlns + "siemens", SiemensNamespace.NamespaceName);
+        root.SetAttributeValue("siemens:version", "1.0");
+        root.SetAttributeValue("siemens:exported", DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
+    }
+
+    private static void StripNamespace(XElement element, XNamespace ns)
+    {
+        var attributes = element.Attributes().Where(a => a.IsNamespaceDeclaration && a.Value == ns.NamespaceName).ToList();
+        foreach (var attribute in attributes)
+        {
+            attribute.Remove();
+        }
+
+        var descendants = element.DescendantsAndSelf().ToList();
+        foreach (var descendant in descendants)
+        {
+            if (descendant.Name.Namespace == ns)
+            {
+                descendant.Name = XNamespace.None + descendant.Name.LocalName;
+            }
+
+            var attributesToRemove = descendant.Attributes().Where(a => a.Name.Namespace == ns).ToList();
+            foreach (var attribute in attributesToRemove)
+            {
+                attribute.Remove();
+            }
+        }
+    }
+
+    private static void RemoveMetadataByPrefix(XElement element, string prefix)
+    {
+        var attributesToRemove = element.DescendantsAndSelf()
+            .SelectMany(x => x.Attributes())
+            .Where(a => a.Name.NamespaceName.Contains(prefix, StringComparison.OrdinalIgnoreCase) ||
+                        a.Name.LocalName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        foreach (var attribute in attributesToRemove)
+        {
+            attribute.Remove();
+        }
+    }
+
+    private static void EnsureDeclaration(XDocument document)
+    {
+        if (document.Declaration is null)
+        {
+            document.Declaration = new XDeclaration("1.0", "utf-8", "yes");
+        }
+        else
+        {
+            document.Declaration.Encoding = document.Declaration.Encoding ?? "utf-8";
+        }
+    }
+
+    private static string CreateSafeFileName(string baseName)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(baseName.Length);
+        foreach (var ch in baseName)
+        {
+            builder.Append(invalidChars.Contains(ch) ? '_' : ch);
+        }
+
+        return builder.Length == 0 ? "document" : builder.ToString();
+    }
+}

--- a/SvgConverterApp/SvgConverterApp.csproj
+++ b/SvgConverterApp/SvgConverterApp.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SvgConverterApp</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/SvgConverterApp/ViewModels/MainViewModel.cs
+++ b/SvgConverterApp/ViewModels/MainViewModel.cs
@@ -1,0 +1,189 @@
+using SvgConverterApp.Commands;
+using SvgConverterApp.Models;
+using SvgConverterApp.Services;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace SvgConverterApp.ViewModels;
+
+public class MainViewModel : ViewModelBase
+{
+    private readonly IFileDialogService _fileDialogService;
+    private readonly ISvgConversionService _conversionService;
+
+    private SvgFormat _selectedInputFormat;
+    private SvgFormat _selectedOutputFormat;
+    private string _statusMessage = "Bereit";
+
+    public MainViewModel(IFileDialogService fileDialogService, ISvgConversionService conversionService)
+    {
+        _fileDialogService = fileDialogService;
+        _conversionService = conversionService;
+
+        Formats = new ObservableCollection<SvgFormat>(Enum.GetValues<SvgFormat>());
+        SelectedInputFormat = SvgFormat.Standard;
+        SelectedOutputFormat = SvgFormat.Inkscape;
+
+        SelectedFiles = new ObservableCollection<string>();
+        ActivityLog = new ObservableCollection<string>();
+
+        BrowseFilesCommand = new RelayCommand(BrowseFiles);
+        ConvertCommand = new AsyncRelayCommand(ConvertAsync, CanConvert);
+    }
+
+    public ObservableCollection<SvgFormat> Formats { get; }
+
+    public ObservableCollection<string> SelectedFiles { get; }
+
+    public ObservableCollection<string> ActivityLog { get; }
+
+    public RelayCommand BrowseFilesCommand { get; }
+
+    public AsyncRelayCommand ConvertCommand { get; }
+
+    public SvgFormat SelectedInputFormat
+    {
+        get => _selectedInputFormat;
+        set
+        {
+            if (SetProperty(ref _selectedInputFormat, value))
+            {
+                ConvertCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public SvgFormat SelectedOutputFormat
+    {
+        get => _selectedOutputFormat;
+        set
+        {
+            if (SetProperty(ref _selectedOutputFormat, value))
+            {
+                ConvertCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        set => SetProperty(ref _statusMessage, value);
+    }
+
+    private void BrowseFiles()
+    {
+        var files = _fileDialogService.OpenFiles("SVG Dateien (*.svg)|*.svg", allowMultiple: true);
+        if (files is null || files.Count == 0)
+        {
+            return;
+        }
+
+        SelectedFiles.Clear();
+        foreach (var file in files)
+        {
+            SelectedFiles.Add(file);
+        }
+
+        ActivityLog.Clear();
+        ActivityLog.Add(files.Count == 1
+            ? "1 Datei bereit zum Konvertieren."
+            : string.Format(CultureInfo.CurrentCulture, "{0} Dateien bereit zum Konvertieren.", files.Count));
+    }
+
+    private bool CanConvert()
+    {
+        return SelectedFiles.Count > 0 && SelectedInputFormat != SelectedOutputFormat;
+    }
+
+    private async Task ConvertAsync()
+    {
+        if (SelectedFiles.Count == 0)
+        {
+            StatusMessage = "Bitte wähle zuerst Dateien aus.";
+            return;
+        }
+
+        if (SelectedInputFormat == SelectedOutputFormat)
+        {
+            StatusMessage = "Eingabe- und Zielformat sind identisch.";
+            return;
+        }
+
+        StatusMessage = "Konvertierung läuft...";
+        ActivityLog.Add("Konvertierung gestartet.");
+
+        if (SelectedFiles.Count == 1)
+        {
+            await ConvertSingleAsync(SelectedFiles[0]);
+        }
+        else
+        {
+            await ConvertBatchAsync();
+        }
+    }
+
+    private async Task ConvertSingleAsync(string filePath)
+    {
+        var defaultName = Path.GetFileNameWithoutExtension(filePath) + GetFormatSuffix(SelectedOutputFormat) + ".svg";
+        var savePath = _fileDialogService.SaveFile(defaultName, "SVG Dateien (*.svg)|*.svg");
+
+        if (string.IsNullOrWhiteSpace(savePath))
+        {
+            ActivityLog.Add("Konvertierung abgebrochen - kein Speicherort gewählt.");
+            StatusMessage = "Bereit";
+            return;
+        }
+
+        await ConvertAndSaveAsync(filePath, savePath);
+    }
+
+    private async Task ConvertBatchAsync()
+    {
+        var folder = _fileDialogService.SelectFolder();
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            ActivityLog.Add("Konvertierung abgebrochen - kein Zielordner gewählt.");
+            StatusMessage = "Bereit";
+            return;
+        }
+
+        var total = SelectedFiles.Count;
+        var index = 0;
+        foreach (var file in SelectedFiles)
+        {
+            index++;
+            var savePath = Path.Combine(folder, Path.GetFileNameWithoutExtension(file) + GetFormatSuffix(SelectedOutputFormat) + ".svg");
+            ActivityLog.Add(string.Format(CultureInfo.CurrentCulture, "[{0}/{1}] {2} wird konvertiert...", index, total, Path.GetFileName(file)));
+            await ConvertAndSaveAsync(file, savePath);
+        }
+
+        ActivityLog.Add("Batch-Konvertierung abgeschlossen.");
+    }
+
+    private async Task ConvertAndSaveAsync(string inputPath, string outputPath)
+    {
+        try
+        {
+            var content = await File.ReadAllTextAsync(inputPath);
+            var converted = await _conversionService.ConvertAsync(content, SelectedInputFormat, SelectedOutputFormat);
+            await File.WriteAllTextAsync(outputPath, converted);
+            ActivityLog.Add(string.Format(CultureInfo.CurrentCulture, "Gespeichert unter {0}.", outputPath));
+            StatusMessage = "Konvertierung abgeschlossen.";
+        }
+        catch (Exception ex)
+        {
+            ActivityLog.Add(string.Format(CultureInfo.CurrentCulture, "Fehler: {0}", ex.Message));
+            StatusMessage = "Konvertierung fehlgeschlagen.";
+        }
+    }
+
+    private static string GetFormatSuffix(SvgFormat format) => format switch
+    {
+        SvgFormat.Standard => "_standard",
+        SvgFormat.Inkscape => "_inkscape",
+        SvgFormat.SiemensSvghmi => "_svghmi",
+        _ => string.Empty
+    };
+}

--- a/SvgConverterApp/ViewModels/ViewModelBase.cs
+++ b/SvgConverterApp/ViewModels/ViewModelBase.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace SvgConverterApp.ViewModels;
+
+public abstract class ViewModelBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a WPF application for converting SVG files between Standard, Inkscape, and Siemens SVG HMI formats
- implement conversion service, file dialog abstractions, and MVVM-based UI with a dark modern theme
- support single-file and batch conversions with activity logging and status updates

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d92606c0b0832cb45a5675c3ba13e7